### PR TITLE
Add support for prefixing the Prometheus metrics

### DIFF
--- a/config.js.template
+++ b/config.js.template
@@ -3,8 +3,9 @@ var config = {};
 config.login     = "";
 config.password  = "";
 
-config.url       = "https://wertpapiere.ing-diba.de/DE/Showpage.aspx?pageID=71";
-config.output    = "csv"; // supported: "csv", "prom"
-config.outfolder = "data/";
+config.url         = "https://wertpapiere.ing-diba.de/DE/Showpage.aspx?pageID=71";
+config.output      = "csv"; // supported: "csv", "prom"
+config.outfolder   = "data/";
+config.prom_prefix = "";
 
 module.exports = config;


### PR DESCRIPTION
* add `config.prom_prefix` config option
* add function to set safe defaults if they are missing from the config file
* add the prefix to the metrics and prometheus metric files

These changes will allow to have the script twice on the same machine, for example running once for daily values (to store intraday metrics) and once in a one-minute interval.

Alex